### PR TITLE
HHH-8535 - Set default value if table sequence row exists but is null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -549,6 +549,7 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 		return "insert into " + renderedTableName + " (" + segmentColumnName + ", " + valueColumnName + ") " + " values (?,?)";
 	}
 
+	@SuppressWarnings("WeakerAccess")
 	protected String buildUpdateNullQuery() {
 		return "update " + renderedTableName +
 				" set " + valueColumnName + "=? " +

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/NullIdInfiniteLoopTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/NullIdInfiniteLoopTest.java
@@ -1,0 +1,61 @@
+package org.hibernate.test.idgen.enhanced.table;
+
+import org.junit.Test;
+
+import org.hibernate.Session;
+import org.hibernate.id.enhanced.TableGenerator;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+
+import static org.hibernate.id.IdentifierGeneratorHelper.BasicHolder;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
+import static org.junit.Assert.assertEquals;
+
+public class NullIdInfiniteLoopTest extends BaseCoreFunctionalTestCase {
+
+    @Override
+    public String[] getMappings() {
+        return new String[] { "idgen/enhanced/table/Basic.hbm.xml" };
+    }
+
+    @Test
+    public void testNormalBoundary() throws InterruptedException {
+        EntityPersister persister = sessionFactory().getMetamodel().entityPersister( Entity.class.getName() );
+        assertClassAssignability( TableGenerator.class, persister.getIdentifierGenerator().getClass() );
+        TableGenerator generator = ( TableGenerator ) persister.getIdentifierGenerator();
+
+        int count = 5;
+        Entity[] entities = new Entity[count];
+        Session s = openSession();
+
+        // This situation can only happen through a bad row inserted via
+        // human being or migration/cloning operation. Simulate this
+        // action post table generation.
+        s.beginTransaction();
+        s.createNativeQuery(
+            "UPDATE ID_TBL_BSC_TBL SET next_val = null where sequence_name = 'test'"
+        ).executeUpdate();
+        s.getTransaction().commit();
+
+        // Failure will result in infinite loop
+        s.beginTransaction();
+        for (int i = 0; i < count; i++) {
+            entities[i] = new Entity("" + (i + 1));
+            s.save(entities[i]);
+            long expectedId = i + 1;
+            assertEquals(expectedId, entities[i].getId().longValue());
+            assertEquals(expectedId, generator.getTableAccessCount());
+            assertEquals(expectedId, ((BasicHolder) generator.getOptimizer().getLastSourceValue()).getActualLongValue());
+        }
+        s.getTransaction().commit();
+
+        s.beginTransaction();
+        for ( int i = 0; i < count; i++ ) {
+            assertEquals( i + 1, entities[i].getId().intValue() );
+            s.delete( entities[i] );
+        }
+        s.getTransaction().commit();
+        s.close();
+    }
+
+}


### PR DESCRIPTION
 - If using org.hibernate.id.enhanced.TableGenerator and an inadvertent
   `null` `next_value` value is stored for a valid `sequence_name` it
   will lead to an infinite loop when generating a new id.

 - If a row is found for the `sequence_name` but a null value is
   stored set that record to the `defaultValue`

- JIRA: https://hibernate.atlassian.net/browse/HHH-8535